### PR TITLE
easing functions added

### DIFF
--- a/Scriptmapper.py
+++ b/Scriptmapper.py
@@ -227,6 +227,9 @@ for b in timed_b:
     parse = text.split(',')
     if len(parse) == 1:
         parse.append('stop')
+        parse.append('False')
+    elif len(parse) == 2:
+        parse.append('False')
     new_line = create_template()
     start_command = parse[0]
     print_log(f'start : {start_command}')
@@ -241,9 +244,16 @@ for b in timed_b:
     new_line['EndPos'] = pos
     new_line['EndRot'] = rot
     new_line['Duration'] = dur
+    ease_command = parse[2]
+    print_log(f'EaseTransition : {ease_command}')
+    if ease_command != 'False':
+        new_lines, log_text = ease(dur, ease_command, new_line)
+        data['Movements'].extend(new_lines)
+        print_log(log_text)
+    else:
+        data['Movements'].append(new_line)
     print_log(f'start POS{new_line["StartPos"]} ROT{new_line["StartRot"]}')
     print_log(f'end POS{new_line["EndPos"]} ROT{new_line["EndRot"]}')
-    data['Movements'].append(new_line)
 
 data['Movements'][0]['Duration'] -= 0.04  # モタるよりも走った方が良いので安全側のオフセット
 

--- a/commands.py
+++ b/commands.py
@@ -256,14 +256,26 @@ def vibro(dur, bpm, param, last_pos_rot):
 
 def ease(dur, text, line):
     log_text = ''
-    easetypes = ['easeInSine','easeOutSine','easeInOutSine','easeInCubic','easeOutCubic','easeInOutCubic',
-                'easeInQuint','easeOutQuint','easeInOutQuint','easeInCirc','easeOutCirc','easeInOutCirc',
-                'easeInElastic','easeOutElastic','easeInOutElastic','easeInQuad','easeOutQuad','easeInOutQuad',
-                'easeInQuart','easeOutQuart','easeInOutQuart','easeInExpo','easeOutExpo','easeInOutExpo',
-                'easeInBack','easeOutBack','easeInOutBack','easeInBounce','easeOutBounce','easeInOutBounce']
+    easetypes = ['InSine','OutSine','InOutSine','InCubic','OutCubic','InOutCubic',
+                'InQuint','OutQuint','InOutQuint','InCirc','OutCirc','InOutCirc',
+                'InElastic','OutElastic','InOutElastic','InQuad','OutQuad','InOutQuad',
+                'InQuart','OutQuart','InOutQuart','InExpo','OutExpo','InOutExpo',
+                'InBack','OutBack','InOutBack','InBounce','OutBounce','InOutBounce']
     flag = 0
     for easetype in easetypes:
-        if text.startswith(easetype):
+        u_text = text.upper()
+        u_easetype = easetype.upper()
+        if u_text=='EASE':
+            break
+        if u_text[:4]=='EASE':
+            u_text = u_text[4:]
+        if u_text[:2]=='IO':
+            u_text = 'INOUT' + u_text[2:]
+        if (u_text[0]=='I') & (u_text[1]!='N'):
+            u_text = 'IN' + u_text[1:]
+        if (u_text[0]=='O') & (u_text[1]!='U'):
+            u_text = 'OUT' + u_text[1:]
+        if u_text.startswith(u_easetype):
             log_text += f'easeコマンド {easetype} を検出'
             easefunc = eval(easetype)
             flag = 1
@@ -272,7 +284,7 @@ def ease(dur, text, line):
         if text.startswith('ease'):
             log_text += f'easeコマンドを検出\n'
             log_text += f'有効なeasing関数名が指定されていないため、easeInOutCubic(CameraPlusデフォルト)を返します'
-            easefunc = easeInOutCubic
+            easefunc = InOutCubic
         else:
             log_text += f'！有効なeaseコマンドを検出できません！\n'
             log_text += f'EaseTransition: False としますが、意図しない演出になっています。'

--- a/easefunc.py
+++ b/easefunc.py
@@ -1,0 +1,135 @@
+from math import cos, pi, sin, sqrt
+
+# Reference: https://easings.net/
+
+def easeInSine(t):
+    return 1 - cos((t * pi) / 2)
+
+def easeOutSine(t):
+  return sin((t * pi) / 2)
+
+def easeInOutSine(t):
+    return -(cos(pi * t) - 1) / 2
+
+def easeInCubic(t):
+    return t * t * t
+
+def easeOutCubic(t):
+    return 1 - pow(1 - t, 3)
+
+def easeInOutCubic(t):
+    return 4 * t * t * t if t < 0.5 else 1 - pow(-2 * t + 2, 3) / 2
+
+def easeInQuint(t):
+    return t * t * t * t * t
+
+def easeOutQuint(t):
+    return 1 - pow(1 - t, 5)
+
+def easeInOutQuint(t):
+    return 16 * t * t * t * t * t if t < 0.5 else 1 - pow(-2 * t + 2, 5) / 2
+
+def easeInCirc(t):
+    return 1 - sqrt(1 - pow(t, 2))
+
+def easeOutCirc(t):
+    return sqrt(1 - pow(t - 1, 2))
+
+def easeInOutCirc(t):
+    return (1 - sqrt(1 - pow(2 * t, 2))) / 2 if t < 0.5 else (sqrt(1 - pow(-2 * t + 2, 2)) + 1) / 2
+
+def easeInElastic(t):
+    c4 = (2 * pi) / 3
+    if t==0:
+        return 0
+    elif t==1:
+        return 1
+    else:
+        return -pow(2, 10 * t - 10) * sin((t * 10 - 10.75) * c4)
+
+def easeOutElastic(t):
+    c4 = (2 * pi) / 3
+    if t==0:
+        return 0
+    elif t==1:
+        return 1
+    else:
+        return pow(2, -10 * t) * sin((t * 10 - 0.75) * c4) + 1
+
+def easeInOutElastic(t):
+    c5 = (2 * pi) / 4.5
+    if t==0:
+        return 0
+    elif t==1:
+        return 1
+    elif t < 0.5:
+        return -(pow(2, 20 * t - 10) * sin((20 * t - 11.125) * c5)) / 2
+    else:
+        return (pow(2, -20 * t + 10) * sin((20 * t - 11.125) * c5)) / 2 + 1
+
+def easeInQuad(t):
+    return t * t
+
+def easeOutQuad(t):
+    return 1 - (1 - t) * (1 - t)
+
+def easeInOutQuad(t):
+    return 2 * t * t if t < 0.5 else 1 - pow(-2 * t + 2, 2) / 2
+
+def easeInQuart(t):
+    return t * t * t * t
+
+def easeOutQuart(t):
+    return 1 - pow(1 - t, 4)
+
+def easeInOutQuart(t):
+    return 8 * t * t * t * t if t < 0.5 else 1 - pow(-2 * t + 2, 4) / 2
+
+def easeInExpo(t):
+    return 0 if t == 0 else pow(2, 10 * t - 10)
+
+def easeOutExpo(t):
+    return 1 if t == 1 else 1 - pow(2, -10 * t)
+
+def easeInOutExpo(t):
+    if t==0:
+        return 0
+    elif t==1:
+        return 1
+    elif t < 0.5:
+        return pow(2, 20 * t - 10) / 2
+    else:
+        return (2 - pow(2, -20 * t + 10)) / 2
+
+def easeInBack(t):
+    c1 = 1.70158
+    c3 = c1 + 1
+    return c3 * t * t * t - c1 * t * t
+
+def easeOutBack(t):
+    c1 = 1.70158
+    c3 = c1 + 1
+    return 1 + c3 * pow(t - 1, 3) + c1 * pow(t - 1, 2)
+
+def easeInOutBack(t):
+    c1 = 1.70158
+    c2 = c1 * 1.525
+    return (pow(2 * t, 2) * ((c2 + 1) * 2 * t - c2)) / 2 if t < 0.5 else (pow(2 * t - 2, 2) * ((c2 + 1) * (t * 2 - 2) + c2) + 2) / 2
+
+def easeInBounce(t):
+    return 1 - easeOutBounce(1 - t)
+
+def easeOutBounce(t):
+    n1 = 7.5625
+    d1 = 2.75
+    if t < (1 / d1):
+        return n1 * t * t
+    elif t < (2 / d1):
+        return n1 * (t - 1.5 / d1)**2 + 0.75
+    elif t < (2.5 / d1):
+        return n1 * (t - 2.25 / d1)**2 + 0.9375
+    else:
+        return n1 * (t - 2.625 / d1)**2 + 0.984375
+
+def easeInOutBounce(t):
+    return (1 - easeOutBounce(1 - 2 * t)) / 2 if t < 0.5 else (1 + easeOutBounce(2 * t - 1)) / 2

--- a/easefunc.py
+++ b/easefunc.py
@@ -2,43 +2,43 @@ from math import cos, pi, sin, sqrt
 
 # Reference: https://easings.net/
 
-def easeInSine(t):
+def InSine(t):
     return 1 - cos((t * pi) / 2)
 
-def easeOutSine(t):
+def OutSine(t):
   return sin((t * pi) / 2)
 
-def easeInOutSine(t):
+def InOutSine(t):
     return -(cos(pi * t) - 1) / 2
 
-def easeInCubic(t):
+def InCubic(t):
     return t * t * t
 
-def easeOutCubic(t):
+def OutCubic(t):
     return 1 - pow(1 - t, 3)
 
-def easeInOutCubic(t):
+def InOutCubic(t):
     return 4 * t * t * t if t < 0.5 else 1 - pow(-2 * t + 2, 3) / 2
 
-def easeInQuint(t):
+def InQuint(t):
     return t * t * t * t * t
 
-def easeOutQuint(t):
+def OutQuint(t):
     return 1 - pow(1 - t, 5)
 
-def easeInOutQuint(t):
+def InOutQuint(t):
     return 16 * t * t * t * t * t if t < 0.5 else 1 - pow(-2 * t + 2, 5) / 2
 
-def easeInCirc(t):
+def InCirc(t):
     return 1 - sqrt(1 - pow(t, 2))
 
-def easeOutCirc(t):
+def OutCirc(t):
     return sqrt(1 - pow(t - 1, 2))
 
-def easeInOutCirc(t):
+def InOutCirc(t):
     return (1 - sqrt(1 - pow(2 * t, 2))) / 2 if t < 0.5 else (sqrt(1 - pow(-2 * t + 2, 2)) + 1) / 2
 
-def easeInElastic(t):
+def InElastic(t):
     c4 = (2 * pi) / 3
     if t==0:
         return 0
@@ -47,7 +47,7 @@ def easeInElastic(t):
     else:
         return -pow(2, 10 * t - 10) * sin((t * 10 - 10.75) * c4)
 
-def easeOutElastic(t):
+def OutElastic(t):
     c4 = (2 * pi) / 3
     if t==0:
         return 0
@@ -56,7 +56,7 @@ def easeOutElastic(t):
     else:
         return pow(2, -10 * t) * sin((t * 10 - 0.75) * c4) + 1
 
-def easeInOutElastic(t):
+def InOutElastic(t):
     c5 = (2 * pi) / 4.5
     if t==0:
         return 0
@@ -67,31 +67,31 @@ def easeInOutElastic(t):
     else:
         return (pow(2, -20 * t + 10) * sin((20 * t - 11.125) * c5)) / 2 + 1
 
-def easeInQuad(t):
+def InQuad(t):
     return t * t
 
-def easeOutQuad(t):
+def OutQuad(t):
     return 1 - (1 - t) * (1 - t)
 
-def easeInOutQuad(t):
+def InOutQuad(t):
     return 2 * t * t if t < 0.5 else 1 - pow(-2 * t + 2, 2) / 2
 
-def easeInQuart(t):
+def InQuart(t):
     return t * t * t * t
 
-def easeOutQuart(t):
+def OutQuart(t):
     return 1 - pow(1 - t, 4)
 
-def easeInOutQuart(t):
+def InOutQuart(t):
     return 8 * t * t * t * t if t < 0.5 else 1 - pow(-2 * t + 2, 4) / 2
 
-def easeInExpo(t):
+def InExpo(t):
     return 0 if t == 0 else pow(2, 10 * t - 10)
 
-def easeOutExpo(t):
+def OutExpo(t):
     return 1 if t == 1 else 1 - pow(2, -10 * t)
 
-def easeInOutExpo(t):
+def InOutExpo(t):
     if t==0:
         return 0
     elif t==1:
@@ -101,25 +101,25 @@ def easeInOutExpo(t):
     else:
         return (2 - pow(2, -20 * t + 10)) / 2
 
-def easeInBack(t):
+def InBack(t):
     c1 = 1.70158
     c3 = c1 + 1
     return c3 * t * t * t - c1 * t * t
 
-def easeOutBack(t):
+def OutBack(t):
     c1 = 1.70158
     c3 = c1 + 1
     return 1 + c3 * pow(t - 1, 3) + c1 * pow(t - 1, 2)
 
-def easeInOutBack(t):
+def InOutBack(t):
     c1 = 1.70158
     c2 = c1 * 1.525
     return (pow(2 * t, 2) * ((c2 + 1) * 2 * t - c2)) / 2 if t < 0.5 else (pow(2 * t - 2, 2) * ((c2 + 1) * (t * 2 - 2) + c2) + 2) / 2
 
-def easeInBounce(t):
-    return 1 - easeOutBounce(1 - t)
+def InBounce(t):
+    return 1 - OutBounce(1 - t)
 
-def easeOutBounce(t):
+def OutBounce(t):
     n1 = 7.5625
     d1 = 2.75
     if t < (1 / d1):
@@ -131,5 +131,5 @@ def easeOutBounce(t):
     else:
         return n1 * (t - 2.625 / d1)**2 + 0.984375
 
-def easeInOutBounce(t):
-    return (1 - easeOutBounce(1 - 2 * t)) / 2 if t < 0.5 else (1 + easeOutBounce(2 * t - 1)) / 2
+def InOutBounce(t):
+    return (1 - OutBounce(1 - 2 * t)) / 2 if t < 0.5 else (1 + OutBounce(2 * t - 1)) / 2


### PR DESCRIPTION
EaseTransition機能を実装しました。
**【使い方】**
`diagf2,diag-2,easeInSine`
のようにカンマで区切られた3番目にeaseで始まる関数名を書きます。
使える関数名は[ここ](https://easings.net/)を参照。
単に`ease`と書いた時やeaseの後に無効な関数名を書いたときは`easeInOutCubic`(CameraPlusデフォルト)とみなされます。
文頭がeaseではない場合はEaseTransition: Falseとします。

**【追記】**
easeコマンドの指定方法を拡張しました。
コマンド指定ルール
・先頭にeaseを書いても書かなくても良い
・大文字小文字は区別されない
・「In」は「I」と略せる
・「Out」は「O」と略せる
・「InOut」は「IO」と略せる
**認識される書き方の例**
・ease
・easeInOutSine
・InOutSine
・IOSine
・isine
・easeOsine
**認識されない書き方の例**
・OISine
・IoutSine
・inoSine