### PR TITLE
BPM Change support for V2.5 and V3.0

### DIFF
--- a/ScriptMapperClass.py
+++ b/ScriptMapperClass.py
@@ -209,6 +209,8 @@ class ScriptMapper:
                 virtual_time += (change['grid'] - bpmchange_grid) * 60 / current_bpm
                 current_bpm = change['bpm']
                 bpmchange_grid = change['grid']
+            if start_check:
+                start_time = virtual_time + (start - bpmchange_grid) * 60 / current_bpm
             if not v1_format:
                 end_time = virtual_time + (end - bpmchange_grid) * 60 / current_bpm
                 command_b[i].duration = end_time - start_time

--- a/ScriptMapperClass.py
+++ b/ScriptMapperClass.py
@@ -82,7 +82,7 @@ class ScriptMapper:
                 if b['_type'] == 100:
                     if self.bpmchanges == []:
                         self.logger.log('V2.5のBPM Eventsを検出')
-                    self.logger.log(f'grid : {b['_time']:6.2f} (BPM : {b['_floatValue']})')
+                    self.logger.log(f'grid : {b["_time"]:6.2f} (BPM : {b["_floatValue"]})')
                     self.bpmchanges.append({
                         'grid': b['_time'],
                         'bpm': b['_floatValue']})
@@ -96,7 +96,7 @@ class ScriptMapper:
                 self.logger.log('CustomDataのBPMChangesを検出')
                 bpmChanges = j['_customData']['_BPMChanges']
                 for b in bpmChanges:
-                    self.logger.log(f'time : {b['_time'] * 60 / bpm:6.2f} (BPM : {b['_BPM']})')
+                    self.logger.log(f'time : {b["_time"] * 60 / bpm:6.2f} (BPM : {b["_BPM"]})')
                     self.bpmchanges.append({
                         'time': b['_time'] * 60 / bpm,
                         'bpm': b['_BPM'],
@@ -106,7 +106,7 @@ class ScriptMapper:
             self.logger.log('V3.0のBPM Eventsを検出')
             bpmChanges = j['bpmEvents'] # V3
             for b in bpmChanges:
-                self.logger.log(f'grid : {b['b']:6.2f} (BPM : {b['m']})')
+                self.logger.log(f'grid : {b["b"]:6.2f} (BPM : {b["m"]})')
                 self.bpmchanges.append({
                     'grid': b['b'],
                     'bpm': b['m']})


### PR DESCRIPTION
ChroMapper 0.9.646(昨年10/2以降のStable)で仕様変更(V2.5.0及びV3.0.0)になったBPM変更の処理に対応しました。

V2.5.0 及び V3.0.0 のBPM Eventsの仕様は以下の通りです
https://bsmg.wiki/mapping/map-format/beatmap.html#bpm-events

以下が従来(V1)形式とV2.5.0以降の比較資料になります。
![image](https://github.com/hibit-at/Scriptmapper/assets/14249877/0f6c20cf-814d-4a32-8eed-f966e1773242)

追記:Python 3.12だとSyntax Errorにならなくて気が付かなかったのですが、3.11以前だとエラーになったので修正しました。
6/19追記:BPM変更が無い譜面(最後のBPM変更よりも後のブックマーク)でdurationの計算が異常値になっていたので修正しました。